### PR TITLE
chore: re-pin logos-package-manager to merged master (shared semver)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9493,11 +9493,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134133,
-        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
+        "lastModified": 1784207525,
+        "narHash": "sha256-D1sVtUEcHjqUyYV0qEP+ORo4g7mzThz0cuHw+Taiwyg=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
+        "rev": "202af6fa0f0f4493bc59c8a609dff9326f78a18d",
         "type": "github"
       },
       "original": {
@@ -10649,11 +10649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Part of the semver-unification chain. Re-pins the wrapped library so the **published module artifact** carries the fix — not just the workspace-integrated build (which already gets it via `follows`).

`logos-co/logos-package-manager#25` merged, moving its `versionGreaterOrEqual` onto the shared `logos::semver` implementation (pre-release ordering: `1.0.0-rc.2` < `1.0.0-rc.11`; and the `install --dir` order fix so an older `.lgx` no longer clobbers a newer one). This bumps the pin from `4871ed19` (pre-fix) to master `202af6f`.

Pure re-pin — this module has no version logic of its own; it forwards to `logos-package-manager`. Transitively moves `logos-package` to master (`8d4236f`) as well.

Verified locally: `nix build .#default` builds the module against the fixed library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)