### PR TITLE
feat: fresh-install gate + thread dep changes through the gated flow

### DIFF
--- a/src/package_manager_impl.cpp
+++ b/src/package_manager_impl.cpp
@@ -1058,6 +1058,13 @@ static std::vector<std::string> dedupeNamesPreserveOrder(
 
 LogosMap PackageManagerImpl::confirmInstall(const std::string& packageName)
 {
+    // A fresh install removes nothing first — unlike confirmUpgrade there is no
+    // doUninstall step. Validate, capture the echo fields, and clear the gate in
+    // ONE critical section so a concurrent cancel / reset / ack-timeout can't swap
+    // the pending action out between the check and the capture (which would make
+    // installApproved carry an empty/wrong payload). Emit outside the lock —
+    // listeners may call back in synchronously.
+    LogosMap payload;
     {
         std::lock_guard<std::mutex> lock(m_stateMutex);
         if (m_pendingAction.op != PendingOp::Install || m_pendingAction.name != packageName) {
@@ -1072,15 +1079,6 @@ LogosMap PackageManagerImpl::confirmInstall(const std::string& packageName)
             response["error"] = "Pending install for '" + packageName + "' has not been acknowledged";
             return response;
         }
-    }
-
-    // A fresh install removes nothing first — unlike confirmUpgrade there is no
-    // doUninstall step. We just clear the gate and tell the initiator (PMU) to
-    // run its download + install chain. Capture the echo fields under the lock,
-    // then emit outside it (listeners may call back in synchronously).
-    LogosMap payload;
-    {
-        std::lock_guard<std::mutex> lock(m_stateMutex);
         payload["name"] = m_pendingAction.name;
         payload["releaseTag"] = m_pendingAction.releaseTag;
         payload["repositoryUrl"] = m_pendingAction.repositoryUrl;

--- a/src/package_manager_impl.cpp
+++ b/src/package_manager_impl.cpp
@@ -532,6 +532,7 @@ const char* PackageManagerImpl::opName(PendingOp op)
     switch (op) {
         case PendingOp::Uninstall:      return "uninstall";
         case PendingOp::Upgrade:        return "upgrade";
+        case PendingOp::Install:        return "install";
         case PendingOp::MultiUninstall: return "multi-uninstall";
         case PendingOp::None:           return "none";
     }
@@ -669,6 +670,11 @@ void PackageManagerImpl::emitCancellation(const PendingAction& pa, const std::st
     } else if (pa.op == PendingOp::Uninstall) {
         payload["name"] = pa.name;
         uninstallCancelled(payload.dump());
+    } else if (pa.op == PendingOp::Install) {
+        payload["name"] = pa.name;
+        payload["releaseTag"] = pa.releaseTag;
+        payload["repositoryUrl"] = pa.repositoryUrl;
+        installCancelled(payload.dump());
     } else if (pa.op == PendingOp::MultiUninstall) {
         LogosList names = LogosList::array();
         for (const auto& n : pa.names) names.push_back(n);
@@ -731,9 +737,30 @@ LogosMap PackageManagerImpl::requestUninstall(const std::string& packageName)
     return response;
 }
 
+// Parse the initiator-supplied depChanges JSON (array of change records) and
+// attach it to a gated-flow event payload under "depChanges". The module never
+// interprets it — it's opaque display data for the host's confirmation dialog —
+// so a malformed / empty string simply yields an empty array rather than an
+// error (the dialog then shows "no other packages need to change").
+static void attachDepChanges(LogosMap& payload, const std::string& depChanges)
+{
+    LogosList changes = LogosList::array();
+    if (!depChanges.empty()) {
+        try {
+            LogosMap parsed = LogosMap::parse(depChanges);
+            if (parsed.is_array())
+                changes = std::move(parsed);
+        } catch (...) {
+            // leave `changes` empty on any parse failure
+        }
+    }
+    payload["depChanges"] = changes;
+}
+
 LogosMap PackageManagerImpl::requestUpgrade(const std::string& packageName,
                                              const std::string& releaseTag,
-                                             int64_t mode)
+                                             int64_t mode,
+                                             const std::string& depChanges)
 {
     LogosMap response;
     // Same rationale as requestUninstall: empty name has to be rejected
@@ -774,11 +801,54 @@ LogosMap PackageManagerImpl::requestUpgrade(const std::string& packageName,
     for (const auto& d : installedDependentsNames(packageName))
         deps.push_back(d);
     payload["installedDependents"] = deps;
+    attachDepChanges(payload, depChanges);
 
     startAckTimerLocked(lock);
 
     lock.unlock();
     beforeUpgrade(payload.dump());
+
+    response["success"] = true;
+    return response;
+}
+
+LogosMap PackageManagerImpl::requestInstall(const std::string& packageName,
+                                             const std::string& releaseTag,
+                                             const std::string& repositoryUrl,
+                                             const std::string& depChanges)
+{
+    LogosMap response;
+    if (packageName.empty()) {
+        response["success"] = false;
+        response["error"] = "Package name cannot be empty";
+        return response;
+    }
+
+    std::unique_lock<std::mutex> lock(m_stateMutex);
+
+    if (m_pendingAction.op != PendingOp::None) {
+        response["success"] = false;
+        response["error"] = pendingDescriptionLocked();
+        return response;
+    }
+
+    m_pendingAction = {};
+    m_pendingAction.op = PendingOp::Install;
+    m_pendingAction.name = packageName;
+    m_pendingAction.releaseTag = releaseTag;
+    m_pendingAction.repositoryUrl = repositoryUrl;
+    m_pendingAction.acked = false;
+
+    LogosMap payload;
+    payload["name"] = packageName;
+    payload["releaseTag"] = releaseTag;
+    payload["repositoryUrl"] = repositoryUrl;
+    attachDepChanges(payload, depChanges);
+
+    startAckTimerLocked(lock);
+
+    lock.unlock();
+    beforeInstall(payload.dump());
 
     response["success"] = true;
     return response;
@@ -985,6 +1055,72 @@ static std::vector<std::string> dedupeNamesPreserveOrder(
 }
 
 } // namespace
+
+LogosMap PackageManagerImpl::confirmInstall(const std::string& packageName)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_stateMutex);
+        if (m_pendingAction.op != PendingOp::Install || m_pendingAction.name != packageName) {
+            LogosMap response;
+            response["success"] = false;
+            response["error"] = "No matching pending install for '" + packageName + "'";
+            return response;
+        }
+        if (!m_pendingAction.acked) {
+            LogosMap response;
+            response["success"] = false;
+            response["error"] = "Pending install for '" + packageName + "' has not been acknowledged";
+            return response;
+        }
+    }
+
+    // A fresh install removes nothing first — unlike confirmUpgrade there is no
+    // doUninstall step. We just clear the gate and tell the initiator (PMU) to
+    // run its download + install chain. Capture the echo fields under the lock,
+    // then emit outside it (listeners may call back in synchronously).
+    LogosMap payload;
+    {
+        std::lock_guard<std::mutex> lock(m_stateMutex);
+        payload["name"] = m_pendingAction.name;
+        payload["releaseTag"] = m_pendingAction.releaseTag;
+        payload["repositoryUrl"] = m_pendingAction.repositoryUrl;
+        m_pendingAction = {};
+        stopAckTimerLocked();
+    }
+    installApproved(payload.dump());
+
+    LogosMap response;
+    response["success"] = true;
+    return response;
+}
+
+LogosMap PackageManagerImpl::cancelInstall(const std::string& packageName)
+{
+    PendingAction pa;
+    {
+        std::lock_guard<std::mutex> lock(m_stateMutex);
+        if (m_pendingAction.op != PendingOp::Install || m_pendingAction.name != packageName) {
+            LogosMap response;
+            response["success"] = false;
+            response["error"] = "No matching pending install for '" + packageName + "'";
+            return response;
+        }
+        // See cancelUninstall for why cancel also requires prior ack.
+        if (!m_pendingAction.acked) {
+            LogosMap response;
+            response["success"] = false;
+            response["error"] = "Pending install for '" + packageName + "' has not been acknowledged";
+            return response;
+        }
+        pa = m_pendingAction;
+        m_pendingAction = {};
+        stopAckTimerLocked();
+    }
+    emitCancellation(pa, "user cancelled");
+    LogosMap response;
+    response["success"] = true;
+    return response;
+}
 
 LogosMap PackageManagerImpl::requestMultiUninstall(const std::vector<std::string>& packageNamesIn)
 {

--- a/src/package_manager_impl.h
+++ b/src/package_manager_impl.h
@@ -127,7 +127,25 @@ public:
     // Only one gated flow can be pending globally (across packages and ops).
     // A second requestXxx while one is pending returns { success: false, error: ... }.
     LogosMap requestUninstall(const std::string& packageName);
-    LogosMap requestUpgrade(const std::string& packageName, const std::string& releaseTag, int64_t mode);
+    // `depChanges` is an optional JSON array of the transitive dependency
+    // changes the initiator resolved for this operation (each entry shaped
+    // { name, action, fromVersion, toVersion, repository }). It is echoed into
+    // the beforeUpgrade / beforeInstall payload so the host's confirmation
+    // dialog can list exactly what else will change — the module treats it as
+    // opaque display data and never parses or acts on it. Empty string = the
+    // initiator resolved no changes (or didn't compute any).
+    LogosMap requestUpgrade(const std::string& packageName, const std::string& releaseTag,
+                            int64_t mode, const std::string& depChanges);
+
+    // Fresh-install gate — the confirmation-only sibling of requestUpgrade.
+    // Gates a not-yet-installed package behind the same listener-ack protocol
+    // so the host shows one confirmation dialog before anything is downloaded.
+    // confirmInstall emits "installApproved" (nothing is uninstalled first);
+    // cancelInstall / the ack timeout emit "installCancelled".
+    LogosMap requestInstall(const std::string& packageName, const std::string& releaseTag,
+                            const std::string& repositoryUrl, const std::string& depChanges);
+    LogosMap confirmInstall(const std::string& packageName);
+    LogosMap cancelInstall(const std::string& packageName);
 
     LogosMap ackPendingAction(const std::string& packageName);
 
@@ -165,20 +183,29 @@ logos_events:
     void uiPluginUninstalled(const std::string& packageName);
     void beforeUninstall(const std::string& payload);
     void beforeUpgrade(const std::string& payload);
+    void beforeInstall(const std::string& payload);
     void beforeMultiUninstall(const std::string& payload);
     void uninstallCancelled(const std::string& payload);
     void upgradeCancelled(const std::string& payload);
+    void installCancelled(const std::string& payload);
     void multiUninstallCancelled(const std::string& payload);
     void upgradeUninstallDone(const std::string& payload);
+    // Fresh-install gate approval. Unlike upgrade (which uninstalls the old
+    // version in-module and signals upgradeUninstallDone), a fresh install has
+    // nothing to remove first: confirmInstall simply emits this so the
+    // initiator (PMU) runs its download + install chain for the approved
+    // package. Payload: { name, releaseTag, repositoryUrl }.
+    void installApproved(const std::string& payload);
 
 private:
-    enum class PendingOp { None, Uninstall, Upgrade, MultiUninstall };
+    enum class PendingOp { None, Uninstall, Upgrade, Install, MultiUninstall };
 
     struct PendingAction {
         PendingOp   op = PendingOp::None;
-        std::string name;             // Uninstall / Upgrade only; empty for MultiUninstall (which uses `names`).
+        std::string name;             // Uninstall / Upgrade / Install; empty for MultiUninstall (which uses `names`).
         std::vector<std::string> names; // MultiUninstall only — full deduped batch
-        std::string releaseTag;        // upgrade only
+        std::string releaseTag;        // upgrade / install only
+        std::string repositoryUrl;     // install only — echoed back in installApproved
         int64_t     mode = 0;          // upgrade only (UpgradeMode enum as int)
         bool        acked = false;
     };

--- a/src/package_manager_impl.h
+++ b/src/package_manager_impl.h
@@ -131,9 +131,10 @@ public:
     // changes the initiator resolved for this operation (each entry shaped
     // { name, action, fromVersion, toVersion, repository }). It is echoed into
     // the beforeUpgrade / beforeInstall payload so the host's confirmation
-    // dialog can list exactly what else will change — the module treats it as
-    // opaque display data and never parses or acts on it. Empty string = the
-    // initiator resolved no changes (or didn't compute any).
+    // dialog can list exactly what else will change. The module parses it only
+    // to re-embed it as a JSON array in the payload (via attachDepChanges) and
+    // never interprets or acts on its contents — it is opaque display data.
+    // Empty string = the initiator resolved no changes (or didn't compute any).
     LogosMap requestUpgrade(const std::string& packageName, const std::string& releaseTag,
                             int64_t mode, const std::string& depChanges);
 

--- a/tests/package_manager_events_test.cpp
+++ b/tests/package_manager_events_test.cpp
@@ -17,8 +17,11 @@ void PackageManagerImpl::corePluginUninstalled(const std::string& name)      { r
 void PackageManagerImpl::uiPluginUninstalled(const std::string& name)        { recordEvent("uiPluginUninstalled", name); }
 void PackageManagerImpl::beforeUninstall(const std::string& payload)         { recordEvent("beforeUninstall", payload); }
 void PackageManagerImpl::beforeUpgrade(const std::string& payload)           { recordEvent("beforeUpgrade", payload); }
+void PackageManagerImpl::beforeInstall(const std::string& payload)           { recordEvent("beforeInstall", payload); }
 void PackageManagerImpl::beforeMultiUninstall(const std::string& payload)    { recordEvent("beforeMultiUninstall", payload); }
 void PackageManagerImpl::uninstallCancelled(const std::string& payload)      { recordEvent("uninstallCancelled", payload); }
 void PackageManagerImpl::upgradeCancelled(const std::string& payload)        { recordEvent("upgradeCancelled", payload); }
+void PackageManagerImpl::installCancelled(const std::string& payload)        { recordEvent("installCancelled", payload); }
 void PackageManagerImpl::multiUninstallCancelled(const std::string& payload) { recordEvent("multiUninstallCancelled", payload); }
 void PackageManagerImpl::upgradeUninstallDone(const std::string& payload)    { recordEvent("upgradeUninstallDone", payload); }
+void PackageManagerImpl::installApproved(const std::string& payload)         { recordEvent("installApproved", payload); }

--- a/tests/test_package_manager.cpp
+++ b/tests/test_package_manager.cpp
@@ -649,7 +649,7 @@ LOGOS_TEST(requestUpgrade_rejects_empty_name) {
     auto t = LogosTestContext("package_manager");
     EventCapture events;
     PackageManagerImpl impl;
-    LogosMap r = impl.requestUpgrade("", "v1.0.0", 0);
+    LogosMap r = impl.requestUpgrade("", "v1.0.0", 0, "");
     LOGOS_ASSERT_FALSE(r["success"].get<bool>());
     LOGOS_ASSERT_EQ(r["error"].get<std::string>(),
                     std::string("Package name cannot be empty"));
@@ -666,7 +666,7 @@ LOGOS_TEST(requestUpgrade_rejects_embedded_package) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LogosMap r = impl.requestUpgrade("core_embed", "v2.0.0", 0);
+    LogosMap r = impl.requestUpgrade("core_embed", "v2.0.0", 0, "");
     LOGOS_ASSERT_FALSE(r["success"].get<bool>());
     LOGOS_ASSERT_EQ(r["error"].get<std::string>(),
                     std::string("Cannot upgrade embedded module 'core_embed'"));
@@ -679,7 +679,7 @@ LOGOS_TEST(requestUpgrade_happy_emits_beforeUpgrade_with_tag_and_mode) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LogosMap r = impl.requestUpgrade("foo", "v2.0.0", 7);
+    LogosMap r = impl.requestUpgrade("foo", "v2.0.0", 7, "");
     LOGOS_ASSERT_TRUE(r["success"].get<bool>());
 
     auto matches = events.all("beforeUpgrade");
@@ -698,7 +698,7 @@ LOGOS_TEST(requestUpgrade_rejects_when_already_pending) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v1.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v1.0.0", 0, "")["success"].get<bool>());
 
     // A second gated op (of either kind) must fail while another is pending.
     LogosMap blocked = impl.requestUninstall("foo");
@@ -845,7 +845,7 @@ LOGOS_TEST(confirmUpgrade_happy_emits_upgradeUninstallDone) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 3)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 3, "")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
 
     LogosMap r = impl.confirmUpgrade("foo", "v2.0.0");
@@ -868,7 +868,7 @@ LOGOS_TEST(confirmUpgrade_suppresses_event_on_uninstall_failure) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
 
     LogosMap r = impl.confirmUpgrade("foo", "v2.0.0");
@@ -882,7 +882,7 @@ LOGOS_TEST(confirmUpgrade_tag_mismatch_returns_error) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
 
     LogosMap r = impl.confirmUpgrade("foo", "v3.0.0");
@@ -908,7 +908,7 @@ LOGOS_TEST(confirmUpgrade_requires_ack_before_confirm) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
 
     LogosMap r = impl.confirmUpgrade("foo", "v2.0.0");
     LOGOS_ASSERT_FALSE(r["success"].get<bool>());
@@ -920,6 +920,147 @@ LOGOS_TEST(confirmUpgrade_requires_ack_before_confirm) {
     // prior ack for protocol uniformity — see cancelUpgrade_requires_ack_before_cancel.
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.cancelUpgrade("foo", "v2.0.0")["success"].get<bool>());
+}
+
+// ---------------------------------------------------------------------------
+// requestInstall / confirmInstall / cancelInstall: the fresh-install gate.
+// Mirrors the upgrade gate but with no in-module uninstall step — confirm
+// emits installApproved so the initiator runs its own download+install.
+// ---------------------------------------------------------------------------
+
+LOGOS_TEST(requestInstall_rejects_empty_name) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LogosMap r = impl.requestInstall("", "v1.0.0", "https://repo", "");
+    LOGOS_ASSERT_FALSE(r["success"].get<bool>());
+    LOGOS_ASSERT_EQ(r["error"].get<std::string>(),
+                    std::string("Package name cannot be empty"));
+    LOGOS_ASSERT_FALSE(events.has("beforeInstall"));
+}
+
+LOGOS_TEST(requestInstall_happy_emits_beforeInstall_with_repo_and_depChanges) {
+    auto t = LogosTestContext("package_manager");
+
+    EventCapture events;
+    PackageManagerImpl impl;
+    // A fresh install need not be already installed — the gate is pure
+    // confirmation. depChanges is opaque JSON the host dialog will render.
+    const std::string depChanges =
+        "[{\"name\":\"dep1\",\"action\":\"install\",\"toVersion\":\"1.2.0\"}]";
+    LogosMap r = impl.requestInstall("newpkg", "v1.0.0", "https://repo/x", depChanges);
+    LOGOS_ASSERT_TRUE(r["success"].get<bool>());
+
+    auto matches = events.all("beforeInstall");
+    LOGOS_ASSERT_EQ(matches.size(), static_cast<size_t>(1));
+    LogosMap payload = LogosMap::parse(matches[0].data);
+    LOGOS_ASSERT_EQ(payload["name"].get<std::string>(), std::string("newpkg"));
+    LOGOS_ASSERT_EQ(payload["releaseTag"].get<std::string>(), std::string("v1.0.0"));
+    LOGOS_ASSERT_EQ(payload["repositoryUrl"].get<std::string>(), std::string("https://repo/x"));
+    // depChanges is embedded as a parsed JSON array, not a re-stringified blob.
+    LOGOS_ASSERT_TRUE(payload["depChanges"].is_array());
+    LOGOS_ASSERT_EQ(payload["depChanges"].size(), static_cast<size_t>(1));
+    LOGOS_ASSERT_EQ(payload["depChanges"][0]["name"].get<std::string>(), std::string("dep1"));
+
+    impl.resetPendingAction();
+}
+
+LOGOS_TEST(requestInstall_empty_depChanges_yields_empty_array) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LOGOS_ASSERT_TRUE(impl.requestInstall("newpkg", "v1.0.0", "", "")["success"].get<bool>());
+
+    LogosMap payload = LogosMap::parse(events.all("beforeInstall")[0].data);
+    LOGOS_ASSERT_TRUE(payload["depChanges"].is_array());
+    LOGOS_ASSERT_EQ(payload["depChanges"].size(), static_cast<size_t>(0));
+
+    impl.resetPendingAction();
+}
+
+LOGOS_TEST(requestInstall_rejects_when_already_pending) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LOGOS_ASSERT_TRUE(impl.requestInstall("newpkg", "v1.0.0", "", "")["success"].get<bool>());
+
+    LogosMap blocked = impl.requestInstall("other", "v1.0.0", "", "");
+    LOGOS_ASSERT_FALSE(blocked["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(blocked["error"].get<std::string>().find("install") != std::string::npos);
+
+    impl.resetPendingAction();
+}
+
+LOGOS_TEST(confirmInstall_happy_emits_installApproved) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LOGOS_ASSERT_TRUE(impl.requestInstall("newpkg", "v1.0.0", "https://repo/x", "")["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.ackPendingAction("newpkg")["success"].get<bool>());
+
+    LogosMap r = impl.confirmInstall("newpkg");
+    LOGOS_ASSERT_TRUE(r["success"].get<bool>());
+
+    auto approved = events.all("installApproved");
+    LOGOS_ASSERT_EQ(approved.size(), static_cast<size_t>(1));
+    LogosMap payload = LogosMap::parse(approved[0].data);
+    LOGOS_ASSERT_EQ(payload["name"].get<std::string>(), std::string("newpkg"));
+    LOGOS_ASSERT_EQ(payload["releaseTag"].get<std::string>(), std::string("v1.0.0"));
+    LOGOS_ASSERT_EQ(payload["repositoryUrl"].get<std::string>(), std::string("https://repo/x"));
+
+    // Gate cleared — a fresh request must now succeed.
+    LOGOS_ASSERT_TRUE(impl.requestInstall("again", "v1.0.0", "", "")["success"].get<bool>());
+    impl.resetPendingAction();
+}
+
+LOGOS_TEST(confirmInstall_requires_ack_before_confirm) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LOGOS_ASSERT_TRUE(impl.requestInstall("newpkg", "v1.0.0", "", "")["success"].get<bool>());
+
+    LogosMap r = impl.confirmInstall("newpkg");
+    LOGOS_ASSERT_FALSE(r["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(r["error"].get<std::string>().find("has not been acknowledged") != std::string::npos);
+    LOGOS_ASSERT_FALSE(events.has("installApproved"));
+
+    impl.resetPendingAction();
+}
+
+LOGOS_TEST(cancelInstall_emits_installCancelled_with_user_reason) {
+    auto t = LogosTestContext("package_manager");
+    EventCapture events;
+    PackageManagerImpl impl;
+    LOGOS_ASSERT_TRUE(impl.requestInstall("newpkg", "v1.0.0", "https://repo/x", "")["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.ackPendingAction("newpkg")["success"].get<bool>());
+
+    LogosMap r = impl.cancelInstall("newpkg");
+    LOGOS_ASSERT_TRUE(r["success"].get<bool>());
+
+    auto cancelled = events.all("installCancelled");
+    LOGOS_ASSERT_EQ(cancelled.size(), static_cast<size_t>(1));
+    LogosMap payload = LogosMap::parse(cancelled[0].data);
+    LOGOS_ASSERT_EQ(payload["name"].get<std::string>(), std::string("newpkg"));
+    LOGOS_ASSERT_EQ(payload["reason"].get<std::string>(), std::string("user cancelled"));
+    LOGOS_ASSERT_FALSE(events.has("installApproved"));
+}
+
+LOGOS_TEST(requestUpgrade_carries_depChanges_in_beforeUpgrade) {
+    auto t = LogosTestContext("package_manager");
+    primeInstalledUserPackage("foo");
+
+    EventCapture events;
+    PackageManagerImpl impl;
+    const std::string depChanges =
+        "[{\"name\":\"dep1\",\"action\":\"upgrade\",\"fromVersion\":\"1.0.0\",\"toVersion\":\"1.2.0\"}]";
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, depChanges)["success"].get<bool>());
+
+    LogosMap payload = LogosMap::parse(events.all("beforeUpgrade")[0].data);
+    LOGOS_ASSERT_TRUE(payload["depChanges"].is_array());
+    LOGOS_ASSERT_EQ(payload["depChanges"].size(), static_cast<size_t>(1));
+    LOGOS_ASSERT_EQ(payload["depChanges"][0]["action"].get<std::string>(), std::string("upgrade"));
+
+    impl.resetPendingAction();
 }
 
 // ---------------------------------------------------------------------------
@@ -964,7 +1105,7 @@ LOGOS_TEST(cancelUpgrade_emits_upgradeCancelled_with_tag_and_reason) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
 
     LogosMap r = impl.cancelUpgrade("foo", "v2.0.0");
@@ -984,7 +1125,7 @@ LOGOS_TEST(cancelUpgrade_tag_mismatch_returns_error) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
     LOGOS_ASSERT_TRUE(impl.ackPendingAction("foo")["success"].get<bool>());
 
     LogosMap r = impl.cancelUpgrade("foo", "v9.9.9");
@@ -1027,7 +1168,7 @@ LOGOS_TEST(cancelUpgrade_requires_ack_before_cancel) {
 
     EventCapture events;
     PackageManagerImpl impl;
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
 
     LogosMap r = impl.cancelUpgrade("foo", "v2.0.0");
     LOGOS_ASSERT_FALSE(r["success"].get<bool>());
@@ -1071,7 +1212,7 @@ LOGOS_TEST(ackTimeout_fires_upgradeCancelled_with_timeout_reason) {
     EventCapture events;
     PackageManagerImpl impl;
     impl.setAckTimeoutMsForTest(30);
-    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0)["success"].get<bool>());
+    LOGOS_ASSERT_TRUE(impl.requestUpgrade("foo", "v2.0.0", 0, "")["success"].get<bool>());
 
     auto e = events.waitFor("upgradeCancelled", 1000);
     LOGOS_ASSERT_EQ(e.name, std::string("upgradeCancelled"));


### PR DESCRIPTION
## What

Adds the module-side plumbing for a **single host-owned confirmation dialog** covering install, upgrade, and downgrade (replacing the double-dialog where package_manager_ui and basecamp both confirmed an upgrade/downgrade).

- **Fresh-install gate**: `requestInstall(name, releaseTag, repositoryUrl, depChanges)` / `confirmInstall(name)` / `cancelInstall(name)` + events `beforeInstall` / `installApproved` / `installCancelled`. Mirrors the existing uninstall/upgrade gate, but a fresh install removes nothing first — `confirmInstall` just emits `installApproved` so the initiator (PMU) runs its own download+install chain.
- **`requestUpgrade` gains a `depChanges` argument** (opaque JSON array of the transitive changes the initiator resolved). It's echoed verbatim into the `beforeUpgrade` / `beforeInstall` payloads so the host dialog can list exactly what else changes. The module never interprets it (malformed/empty → empty array).

## Tests

+7 unit tests (install gate happy/reject/ack/cancel paths + depChanges threading). Full suite **98 green** (`nix build .#unit-tests`).

## Depends on / consumed by

Consumed by **logos-basecamp** (renders the dialog) and **logos-package-manager-ui** (routes through the gate) — this PR should land first, then those re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)