### PR TITLE
chore(deps): bump onto the module-builder that restores the view hook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270089,
-        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
         "type": "github"
       },
       "original": {
@@ -279,7 +279,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_6",
         "logos-nix": "logos-nix_12",
-        "logos-protocol": "logos-protocol_2",
+        "logos-protocol": "logos-protocol_3",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -351,7 +351,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_5",
+        "logos-protocol": "logos-protocol_6",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -419,7 +419,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_10",
+        "logos-protocol": "logos-protocol_11",
         "nixpkgs": [
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -512,7 +512,7 @@
         "logos-nix": "logos-nix_49",
         "logos-package-manager": "logos-package-manager_2",
         "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_7",
+        "logos-protocol": "logos-protocol_8",
         "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-module-builder",
@@ -942,11 +942,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -1095,11 +1095,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -1357,11 +1357,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1787365695,
-        "narHash": "sha256-f20KxGSgoll2cvtgxnASooKuZx87Ly9K7p5XtkN0V1Y=",
+        "lastModified": 1787447341,
+        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "352df67cd6cfa441397495876e21b0d5df93d9f6",
+        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
         "type": "github"
       },
       "original": {
@@ -1378,7 +1378,7 @@
         "logos-nix": "logos-nix_21",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_3",
-        "logos-protocol": "logos-protocol_3",
+        "logos-protocol": "logos-protocol_4",
         "logos-qt-sdk": "logos-qt-sdk_2",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": [
@@ -3780,11 +3780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -3848,11 +3848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -4237,11 +4237,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
         "type": "github"
       },
       "original": {
@@ -4251,6 +4251,33 @@
       }
     },
     "logos-protocol_10": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_11": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4281,7 +4308,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_11": {
+    "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4312,6 +4339,35 @@
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_3": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
@@ -4339,7 +4395,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_3": {
+    "logos-protocol_4": {
       "inputs": {
         "logos-nix": "logos-nix_26",
         "nixpkgs": [
@@ -4367,7 +4423,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_4": {
+    "logos-protocol_5": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4402,7 +4458,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_5": {
+    "logos-protocol_6": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4441,7 +4497,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_6": {
+    "logos-protocol_7": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4476,7 +4532,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_7": {
+    "logos-protocol_8": {
       "inputs": {
         "logos-nix": "logos-nix_56",
         "nixpkgs": [
@@ -4502,7 +4558,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_8": {
+    "logos-protocol_9": {
       "inputs": {
         "logos-nix": [
           "logos-module-builder",
@@ -4521,33 +4577,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_9": {
-      "inputs": {
-        "logos-nix": [
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -4602,11 +4631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268585,
-        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
+        "lastModified": 1787442773,
+        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
+        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
         "type": "github"
       },
       "original": {
@@ -4821,6 +4850,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_2",
         "nixpkgs": [
           "logos-module-builder",
           "logos-rust-sdk",
@@ -4829,11 +4859,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312984,
-        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -4904,7 +4934,7 @@
         "logos-liblogos": "logos-liblogos",
         "logos-nix": "logos-nix_59",
         "logos-plugin-qt": "logos-plugin-qt_8",
-        "logos-protocol": "logos-protocol_8",
+        "logos-protocol": "logos-protocol_9",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
           "logos-module-builder",
@@ -4943,7 +4973,7 @@
         ],
         "logos-nix": "logos-nix_29",
         "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": "logos-protocol_4",
+        "logos-protocol": "logos-protocol_5",
         "logos-qt-sdk": "logos-qt-sdk_3",
         "nixpkgs": [
           "logos-module-builder",
@@ -4978,7 +5008,7 @@
         ],
         "logos-nix": "logos-nix_62",
         "logos-plugin-qt": "logos-plugin-qt_9",
-        "logos-protocol": "logos-protocol_9",
+        "logos-protocol": "logos-protocol_10",
         "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-module-builder",
@@ -5041,7 +5071,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-nix": "logos-nix_31",
         "logos-plugin-qt": "logos-plugin-qt_6",
-        "logos-protocol": "logos-protocol_6",
+        "logos-protocol": "logos-protocol_7",
         "nixpkgs": [
           "logos-module-builder",
           "logos-standalone-app",
@@ -5072,7 +5102,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-nix": "logos-nix_64",
         "logos-plugin-qt": "logos-plugin-qt_10",
-        "logos-protocol": "logos-protocol_11",
+        "logos-protocol": "logos-protocol_12",
         "nixpkgs": [
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -5108,11 +5138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
         "owner": "logos-co",
         "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-module-builder` `352df67` → `e45caf1`, which carries `logos-view-module` `1f95a75` → `d6c8885` and with it the module teardown hook that generated view plugins had been missing (module-builder#214).

See the [logos-test-modules PR](https://github.com/logos-co/logos-test-modules/pulls) for the full story — the same bump there is what unblocks [logos-basecamp#358](https://github.com/logos-co/logos-basecamp/pull/358).

Only `logos-module-builder` moves at root. Verified on **aarch64-darwin and x86_64-linux**: every check plus every module output.

## A correction worth recording

`352df67` is module-builder **#210**, which *predates* the #211 migration — so this repo was never inside the "#211 → #214 broken window" I first assumed. It was on the older `logos-qt-generator` path, whose ui emitter also had no hook. Same outcome, different cause; the bump crosses into the fixed state either way.

## Instrument caveat

`lm methods` is **not** a raw meta-object dump for provider plugins — `logos-module/src/logos_module.cpp:283` takes a `LogosProviderPlugin` early-return that never reaches the walk at `:315`, so lifecycle methods are omitted and it reports *absent* for a plugin that `nm -gU | c++filt` shows carrying them. Verifying a hook this way needs `QPluginLoader` + `QMetaObject`, or `nm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)